### PR TITLE
[npm run-scripts] Support Windows

### DIFF
--- a/protractor/package.json
+++ b/protractor/package.json
@@ -4,10 +4,10 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "postinstall": "$(npm bin)/webdriver-manager update",
-    "scrape-mufg": "$(npm bin)/protractor --specs mufg.js",
-    "scrape-smbc": "tsc smbc.ts && $(npm bin)/protractor --specs smbc.js",
-    "scrape-amazon-affiliate": "$(npm bin)/protractor --specs amazon-affiliate.js"
+    "postinstall": "webdriver-manager update",
+    "scrape-mufg": "protractor --specs mufg.js",
+    "scrape-smbc": "tsc smbc.ts && protractor --specs smbc.js",
+    "scrape-amazon-affiliate": "protractor --specs amazon-affiliate.js"
   },
   "author": "motemen <motemen@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Windows でも `scrape-smbc` 以外の npm run-scripts が実行できるようにしました。
## 要点
- run-scripts の中では `npm bin` のファイルパスは PATH に自動的に追加されるようです。
- `$(...)`  を使うと Windows では実行できません
- `scrape-smbc` は `&&` を使っているのでこの修正後も実行できなさそうです (すみません、未確認です)
  - Windows では代わりに `&` を使うはずです
