### PR TITLE
[npm run scrape-rakuten] Support rakuten bank

### DIFF
--- a/protractor/package.json
+++ b/protractor/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "postinstall": "webdriver-manager update",
     "scrape-mufg": "protractor --specs mufg.js",
+    "scrape-rakuten": "protractor --specs rakuten.js",
     "scrape-smbc": "tsc smbc.ts && protractor --specs smbc.js",
     "scrape-amazon-affiliate": "protractor --specs amazon-affiliate.js"
   },
@@ -13,6 +14,8 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
+    "iconv": "^2.2.0",
+    "inbox": "^1.1.59",
     "protractor": "^1.3.0"
   }
 }

--- a/protractor/package.json
+++ b/protractor/package.json
@@ -4,10 +4,10 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "postinstall": "$(npm bin)/webdriver-manager update",
-    "scrape-mufg": "$(npm bin)/protractor --specs mufg.js",
-    "scrape-smbc": "tsc smbc.ts && $(npm bin)/protractor --specs smbc.js",
-    "scrape-amazon-affiliate": "$(npm bin)/protractor --specs amazon-affiliate.js"
+    "postinstall": "webdriver-manager update",
+    "scrape-mufg": "protractor --specs mufg.js",
+    "scrape-smbc": "tsc smbc.ts && protractor --specs smbc.js",
+    "scrape-amazon-affiliate": "protractor --specs amazon-affiliate.js"
   },
   "author": "motemen <motemen@gmail.com>",
   "license": "MIT",

--- a/protractor/protractor.conf.js
+++ b/protractor/protractor.conf.js
@@ -38,11 +38,17 @@ exports.config = {
     rakuten: {
       id: process.env.RAKUTEN_ID,
       password: process.env.RAKUTEN_PASSWORD,
-      questions: [
-        [/出身地は？/, '(答え)'],
-        [/初めて飼ったペットの名前は？/, '(答え)'],
-        [/所有している車は？/, '(答え)']
-      ],
+      questions: (function () {
+        var questions = [];
+        for (var i = 1; process.env['RAKUTEN_QUESTIONS_' + i]; ++i) {
+          var qa = process.env['RAKUTEN_QUESTIONS_' + i].split(/\t+/);
+          if (qa.length !== 2) {
+            break;
+          }
+          questions.push([new RegExp(qa[0]), qa[1]]);
+        }
+        return questions;
+      })(),
       imap: {
         server: 'imap.gmail.com',
         id: process.env.RAKUTEN_IMAP_ID,

--- a/protractor/protractor.conf.js
+++ b/protractor/protractor.conf.js
@@ -42,11 +42,12 @@ exports.config = {
         [/出身地は？/, '(答え)'],
         [/初めて飼ったペットの名前は？/, '(答え)'],
         [/所有している車は？/, '(答え)']
-      ]
-    },
-    gmail: {
-      id: process.env.GMAIL_ID,
-      password: process.env.GMAIL_PASSWORD
+      ],
+      imap: {
+        server: 'imap.gmail.com',
+        id: process.env.RAKUTEN_IMAP_ID,
+        password: process.env.RAKUTEN_IMAP_PASSWORD
+      }
     },
     smbc: {
       account: process.env.SMBC_ACCOUNT,

--- a/protractor/protractor.conf.js
+++ b/protractor/protractor.conf.js
@@ -35,6 +35,19 @@ exports.config = {
       id: process.env.MUFG_ID,
       password: process.env.MUFG_PASSWORD
     },
+    rakuten: {
+      id: process.env.RAKUTEN_ID,
+      password: process.env.RAKUTEN_PASSWORD,
+      questions: [
+        [/出身地は？/, '(答え)'],
+        [/初めて飼ったペットの名前は？/, '(答え)'],
+        [/所有している車は？/, '(答え)']
+      ]
+    },
+    gmail: {
+      id: process.env.GMAIL_ID,
+      password: process.env.GMAIL_PASSWORD
+    },
     smbc: {
       account: process.env.SMBC_ACCOUNT,
       password: process.env.SMBC_PASSWORD

--- a/protractor/rakuten.js
+++ b/protractor/rakuten.js
@@ -1,0 +1,168 @@
+var fs = require('fs');
+var inbox = require('inbox');
+var iconv = require('iconv');
+var converter = new iconv.Iconv("ISO-2022-JP", "UTF-8");
+
+var lastMonth = new Date();
+    lastMonth.setMonth(lastMonth.getMonth() - 1);
+
+var outFilePath = [
+  'rakuten-', lastMonth.getFullYear(), '-', (lastMonth.getMonth() + 101).toString().substr(-2), '.tsv'
+].join('');
+
+// ワンタイムキー取得用プロミス
+var oneTimeKeyPromise;
+var oneTimeKey;
+
+describe('rakuten', function () {
+  browser.ignoreSynchronization = true;
+  browser.driver.get('https://fes.rakuten-bank.co.jp/MS/main/RbS?CurrentPageID=START&&COMMAND=LOGIN');
+
+  it('Gmailにログインしてワンタイムキー通知メールを取得できるようイベント監視', function () {
+    // http://ayapi.github.io/posts/observingimaponnode/
+    // http://liginc.co.jp/web/service/facebook/153850
+
+    var deferred = protractor.promise.defer();
+    oneTimeKeyPromise = deferred.promise;
+
+    var imap = inbox.createConnection(
+      false, 'imap.gmail.com', {
+        secureConnection: true,
+        auth: {
+          user: browser.params.gmail.id,
+          pass: browser.params.gmail.password
+        }
+      }
+    );
+
+    imap.on('connect', function() {
+      console.log('connected');
+      imap.openMailbox('INBOX', function(error){
+        if(error) throw error;
+      });
+    });
+
+    imap.on('new', function(message) {
+      if (message.from.address !== 'service@ac.rakuten-bank.co.jp') {
+        console.log('this message is not from rakuten bank. skip.');
+        console.log(message.title);
+        console.log(message.from.address);
+        return;
+      }
+      var body = '';
+      var stream = imap.createMessageStream(message.UID);
+      stream.on("data", function(chunk) {
+        body += chunk;
+      });
+      stream.on("end", function() {
+        body = converter.convert(body).toString();
+        // FIXME: body にはヘッダ部も含まれているため RFC822 に則ってちゃんとパースする？
+        if (/ワンタイムキー[ 　]*[:：][ 　]*([a-zA-Z0-9]+)/.test(body)) {
+          var otKey = RegExp.$1;
+          console.log('ワンタイムキーを本文から取得成功:' + otKey);
+          deferred.fulfill(otKey);
+        } else {
+          console.log('ワンタイムキーを本文から取得失敗');
+          deferred.reject();
+        }
+      });
+    });
+
+    imap.connect();
+  });
+
+  it('楽天銀行ログイン', function () {
+    $('.user_id').sendKeys(browser.params.rakuten.id);
+    $('.login_password').sendKeys(browser.params.rakuten.password);
+    $('[value="ログイン"]').click();
+  });
+
+  it('ワンタイムキーを発行する', function () {
+    $('[src="/rb/fes/img/common/btn_onetime.gif"]').element(by.xpath('..')).click();
+  });
+
+  it('Gmailからワンタイムキーを取得', function () {
+    browser.driver.wait(function () {
+      return oneTimeKeyPromise;
+    }, 60 * 1000, 'ワンタイムキーパスワード記載のメールを1分待つ')
+    .then(function (otKey) {
+      console.log('then(): otKey = ' + otKey);
+      oneTimeKey = otKey;
+      expect(typeof oneTimeKey).toBe('string');
+      expect(oneTimeKey).not.toBe('');
+    }, function (err) {
+      console.log('Promise failure: ');
+      console.log(err);
+    });
+  }, 60 * 1000);
+
+  it('ワンタイムキーを入力してログインする', function () {
+    $('.security_code').sendKeys(oneTimeKey);
+    $('[value="一時解除実行"]').click();
+  });
+
+  it('本人確認', function () {
+    element(by.cssContainingText('div', 'ご本人確認のため、以下の認証情報を入力してください。'))
+    .isPresent().then(function (b) {
+      console.log('本人確認テキストが存在したか？ = ' + b);
+      if (!b) return;
+      // 「質問」
+      $('#INPUT_FORM > table.margintop20 > tbody > tr:nth-child(2) > td > table > tbody > tr:nth-child(1) > td > div')
+      .getText().then(function (questionText) {
+        expect(typeof questionText).toBe('string');
+        expect(questionText).not.toBe('');
+        console.log('質問：' + questionText);
+        // 「合言葉」
+        var $answer = $('#INPUT_FORM > table.margintop20 > tbody > tr:nth-child(2) > td > table > tbody > tr:nth-child(2) > td > div > input');
+        var myQuestions = browser.params.rakuten.questions;
+        var i;
+        for (i = 0; i < myQuestions.length; i++) {
+          if (myQuestions[i][0].test(questionText)) {
+            console.log('合言葉を入力：' + myQuestions[i][1]);
+            $answer.sendKeys(myQuestions[i][1]);
+            break;
+          }
+        }
+        console.log('合言葉の入力を終了');
+        if (i >= myQuestions.length) {
+          fail('最後まで見つからなかった');
+        }
+        $('[value="次 へ"]').click();
+        console.log('次へ - クリック');
+      });
+    });
+  });
+
+  it('お知らせ', function () {
+    var $next = $('[value="　次へ （MyAccount）　"]');
+    $next.isPresent().then(function (b) {
+      console.log('次へボタンが存在したか？ = ' + b);
+      if (!b) return;
+      $next.click();
+    });
+  });
+
+  it('先月の明細を取得', function () {
+    element(by.linkText('入出金明細')).click();
+  });
+
+  it('ファイルに書き出す', function () {
+    // 「最新の入出金明細（最大50件・24ヶ月以内）」
+    $$('body > center:nth-child(4) > table > tbody > tr > td > table > tbody > tr > td > div.innerbox00 > table tr').map(function (tr) {
+      return tr.all(by.css('td')).map(function (td) { return td.getText() });
+    }).then(function (rows) {
+      var content = rows.filter(function (cols) {
+        return cols.length === 4;
+      }).map(function (cols) {
+        return cols.map(function (col) { return col.replace(/\s+/g, ' ') }).join('\t');
+      }).join('\n');
+
+      fs.writeFileSync(outFilePath, content);
+      console.log('wrote: ' + outFilePath);
+    });
+  });
+
+  it('', function () {
+      browser.pause();
+  });
+});

--- a/protractor/rakuten.js
+++ b/protractor/rakuten.js
@@ -18,7 +18,7 @@ describe('rakuten', function () {
   browser.ignoreSynchronization = true;
   browser.driver.get('https://fes.rakuten-bank.co.jp/MS/main/RbS?CurrentPageID=START&&COMMAND=LOGIN');
 
-  it('Gmailにログインしてワンタイムキー通知メールを取得できるようイベント監視', function () {
+  it('IMAPサーバにログインしてワンタイムキー通知メールを取得できるようイベント監視', function () {
     // http://ayapi.github.io/posts/observingimaponnode/
     // http://liginc.co.jp/web/service/facebook/153850
 
@@ -26,11 +26,11 @@ describe('rakuten', function () {
     oneTimeKeyPromise = deferred.promise;
 
     var imap = inbox.createConnection(
-      false, 'imap.gmail.com', {
+      false, browser.params.rakuten.imap.server, {
         secureConnection: true,
         auth: {
-          user: browser.params.gmail.id,
-          pass: browser.params.gmail.password
+          user: browser.params.rakuten.imap.id,
+          pass: browser.params.rakuten.imap.password
         }
       }
     );
@@ -81,7 +81,7 @@ describe('rakuten', function () {
     $('[src="/rb/fes/img/common/btn_onetime.gif"]').element(by.xpath('..')).click();
   });
 
-  it('Gmailからワンタイムキーを取得', function () {
+  it('IMAPサーバからワンタイムキーを取得', function () {
     browser.driver.wait(function () {
       return oneTimeKeyPromise;
     }, 60 * 1000, 'ワンタイムキーパスワード記載のメールを1分待つ')

--- a/protractor/rakuten.js
+++ b/protractor/rakuten.js
@@ -161,8 +161,4 @@ describe('rakuten', function () {
       console.log('wrote: ' + outFilePath);
     });
   });
-
-  it('', function () {
-      browser.pause();
-  });
 });


### PR DESCRIPTION
入出金明細をTSVでダウンロードする `npm run scrape-rakuten` を追加しました。
## 要点
- コンフリクトすると思ったので #2 のブランチをベースにしちゃってます
- ワンタイムキーを取得するために IMAP で Gmail に接続しています
  - ~~接続先が `smtp.gmail.com` 固定なので現在は Gmail のみの対応です~~
