### PR TITLE
Add rakuten bank description to README

### DIFF
--- a/protractor/README.adoc
+++ b/protractor/README.adoc
@@ -4,12 +4,38 @@ Scrape websites using http://angular.github.io/protractor/[Protoractor].
 
 	npm install
 	npm run scrape-mufg
+	npm run scrape-rakuten
 
 == MUFG
 
-Scrapes http://direct.bk.mufg.jp/[三菱東京UFJ銀行] and prints current balance and stores last month's details to __YYYY__-__mm__.tsv.
+Scrapes http://direct.bk.mufg.jp/[三菱東京UFJ銀行] and prints current balance and stores last month's details to mufg-__YYYY__-__mm__.tsv.
 
 Required environment variables:
 
 * `MUFG_ID`
 * `MUFG_PASSWORD`
+
+== Rakuten
+
+Scrapes https://www.rakuten-bank.co.jp/[楽天銀行] and prints current balance and stores last month's details to rakuten-__YYYY__-__mm__.tsv.
+
+Required environment variables:
+
+* `RAKUTEN_ID`
+* `RAKUTEN_PASSWORD`
+* `RAKUTEN_IMAP_ID`
+** Gmail IMAP account
+* `RAKUTEN_IMAP_PASSWORD`
+** Gmail IMAP password
+
+* `RAKUTEN_QUESTIONS_{no}`
+** Questions and answers which are displayed when logging in rakuten bank
+** Separated by tab (\\t) character
+
+=== Example
+
+----
+export RAKUTEN_QUESTIONS_1='出身地は？(tab)...'
+export RAKUTEN_QUESTIONS_2='初めて飼ったペットの名前は？(tab)...'
+export RAKUTEN_QUESTIONS_3='所有している車は？(tab)...'
+----


### PR DESCRIPTION
ref. #3 

## 変更点

* 楽天銀行の設定の説明を README に追加しました
* 三菱東京UFJ銀行のスクリプトの出力ファイルのフォーマットが README と違っているようだったので修正しました

## 気になること

RAKUTEN_IMAP_ID, RAKUTEN_IMAP_PASSWORD を「`Gmail IMAP (account|password)`」と説明してしまっているのは、現在、環境変数から IMAP サーバを設定することができないため `imap.gmail.com` 固定になってしまっているためです。
私の動作確認用の環境が整い次第、また環境変数で指定できるようにプルリクエストを送ろうと思います。
（環境変数が増えすぎてしまうので、いっそ protractor.conf.js を直接いじってというのもアリかもしれません…）